### PR TITLE
Fix ability score generation display

### DIFF
--- a/.godot/editor/CharacterCreation.tscn-editstate-2f07377bf4ec7495277df61b21d2e944.cfg
+++ b/.godot/editor/CharacterCreation.tscn-editstate-2f07377bf4ec7495277df61b21d2e944.cfg
@@ -8,7 +8,7 @@ Anim={
 "grid_snap_active": false,
 "grid_step": Vector2(8, 8),
 "grid_visibility": 1,
-"ofs": Vector2(-1294.79, -200.122),
+"ofs": Vector2(-521.364, -38.6364),
 "primary_grid_step": Vector2i(8, 8),
 "show_group_gizmos": true,
 "show_guides": true,
@@ -34,7 +34,7 @@ Anim={
 "snap_rotation_step": 0.261799,
 "snap_scale": false,
 "snap_scale_step": 0.1,
-"zoom": 0.513158
+"zoom": 1.1
 }
 3D={
 "fov": 70.01,
@@ -192,4 +192,4 @@ Game={
 "hide_selection": false,
 "select_mode": 0
 }
-selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@21301/@Panel@14/@VBoxContainer@15/DockHSplitLeftL/DockHSplitLeftR/DockHSplitMain/@VBoxContainer@26/DockVSplitCenter/@VSplitContainer@54/@VBoxContainer@55/@EditorMainScreen@102/MainScreen/@CanvasItemEditor@11482/@VSplitContainer@11134/@HSplitContainer@11136/@HSplitContainer@11138/@Control@11139/@SubViewportContainer@11140/@SubViewport@11141/CharacterCreation/AbilityGeneration")])
+selected_nodes=Array[NodePath]([])

--- a/.godot/editor/CharacterCreation.tscn-folding-2f07377bf4ec7495277df61b21d2e944.cfg
+++ b/.godot/editor/CharacterCreation.tscn-folding-2f07377bf4ec7495277df61b21d2e944.cfg
@@ -2,4 +2,4 @@
 
 node_unfolds=[NodePath("AbilityGeneration"), PackedStringArray("Layout"), NodePath("AbilityGeneration/Margins"), PackedStringArray("Layout", "Theme Overrides", "Theme Overrides/constants"), NodePath("AbilityGeneration/Margins/VBox"), PackedStringArray("Layout"), NodePath("AbilityGeneration/Margins/VBox/Title"), PackedStringArray("Layout", "Theme"), NodePath("AbilityGeneration/Margins/VBox/StoreRow/Spacer"), PackedStringArray("Layout", "Layout/Container Sizing"), NodePath("AbilityGeneration/Margins/VBox/NavButtons/BackButton"), PackedStringArray("Focus"), NodePath("AbilityAssigning"), PackedStringArray("button_paths")]
 resource_unfolds=["res://Scenes/CharacterCreation/CharacterCreation.tscn::StyleBoxFlat_i3y6d", PackedStringArray(), "res://Scenes/CharacterCreation/CharacterCreation.tscn::GDScript_i3y6d", PackedStringArray()]
-nodes_folded=[NodePath("AbilityGeneration")]
+nodes_folded=[]

--- a/.godot/editor/Main.tscn-editstate-a8e1520d83f25710dd4e3da8c6f32601.cfg
+++ b/.godot/editor/Main.tscn-editstate-a8e1520d83f25710dd4e3da8c6f32601.cfg
@@ -8,7 +8,7 @@ Anim={
 "grid_snap_active": false,
 "grid_step": Vector2(8, 8),
 "grid_visibility": 1,
-"ofs": Vector2(-383.545, -74.4186),
+"ofs": Vector2(-1294.79, -200.122),
 "primary_grid_step": Vector2i(8, 8),
 "show_group_gizmos": true,
 "show_guides": true,
@@ -34,7 +34,7 @@ Anim={
 "snap_rotation_step": 0.261799,
 "snap_scale": false,
 "snap_scale_step": 0.1,
-"zoom": 0.751315
+"zoom": 0.513158
 }
 3D={
 "fov": 70.01,
@@ -192,4 +192,4 @@ Game={
 "hide_selection": false,
 "select_mode": 0
 }
-selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@21301/@Panel@14/@VBoxContainer@15/DockHSplitLeftL/DockHSplitLeftR/DockHSplitMain/@VBoxContainer@26/DockVSplitCenter/@VSplitContainer@54/@VBoxContainer@55/@EditorMainScreen@102/MainScreen/@CanvasItemEditor@11482/@VSplitContainer@11134/@HSplitContainer@11136/@HSplitContainer@11138/@Control@11139/@SubViewportContainer@11140/@SubViewport@11141/CharacterCreation/AbilityGeneration")])
+selected_nodes=Array[NodePath]([])

--- a/.godot/editor/editor_layout.cfg
+++ b/.godot/editor/editor_layout.cfg
@@ -30,10 +30,10 @@ dock_5="Inspector,Node,History"
 
 open_scenes=PackedStringArray("res://Scenes/Main.tscn", "res://Scenes/CharacterCreation/CharacterCreation.tscn")
 current_scene="res://Scenes/CharacterCreation/CharacterCreation.tscn"
-center_split_offset=-346
-selected_default_debugger_tab_idx=1
+center_split_offset=-352
+selected_default_debugger_tab_idx=0
 selected_main_editor_idx=2
-selected_bottom_panel_item=0
+selected_bottom_panel_item=1
 
 [EditorWindow]
 
@@ -44,7 +44,7 @@ position=Vector2i(0, 23)
 [ScriptEditor]
 
 open_scripts=["res://Scripts/CharacterCreation/AbilityAssigning.gd", "res://Scripts/CharacterCreation/CharacterCreation.gd", "res://Scripts/DataSchemas/CharacterData.cs", "res://Scripts/DataSchemas/ClassData.cs", "res://Scripts/DataSchemas/FeatData.cs", "res://Scripts/Main.gd", "res://Scripts/DataSchemas/RaceData.cs", "res://Scripts/DataSchemas/SpellData.cs"]
-selected_script="res://Scripts/CharacterCreation/CharacterCreation.gd"
+selected_script=""
 open_help=[]
 script_split_offset=200
 list_split_offset=0
@@ -52,7 +52,7 @@ zoom_factor=1.0
 
 [GameView]
 
-floating_window_rect=Rect2i(498, 278, 1164, 695)
+floating_window_rect=Rect2i(378, 155, 1164, 695)
 floating_window_screen=0
 
 [ShaderEditor]

--- a/.godot/editor/filesystem_update4
+++ b/.godot/editor/filesystem_update4
@@ -1,0 +1,9 @@
+res://Scenes/Main.tscn
+res://Scripts/DataSchemas/RaceData.cs
+res://Scenes/CharacterCreation/CharacterCreation.tscn
+res://Scripts/DataSchemas/SpellData.cs
+res://Scripts/DataSchemas/ClassData.cs
+res://Scripts/DataSchemas/CharacterData.cs
+res://Scripts/DataSchemas/FeatData.cs
+res://Scripts/CharacterCreation/CharacterCreation.gd
+res://Scripts/CharacterCreation/AbilityAssigning.gd

--- a/.godot/editor/script_editor_cache.cfg
+++ b/.godot/editor/script_editor_cache.cfg
@@ -17,11 +17,11 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 52,
+"column": 40,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 53,
-"scroll_position": 35.0,
+"row": 166,
+"scroll_position": 160.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }
@@ -101,11 +101,11 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 0,
+"column": 36,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 64,
-"scroll_position": 0.0,
+"row": 23,
+"scroll_position": 14.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }

--- a/Scenes/CharacterCreation/CharacterCreation.tscn
+++ b/Scenes/CharacterCreation/CharacterCreation.tscn
@@ -162,54 +162,83 @@ text = "Str:"
 
 [node name="StrVal" type="Label" parent="AbilityGeneration/Margins/VBox/Grid/StrBut"]
 layout_mode = 0
-offset_right = 40.0
-offset_bottom = 23.0
+offset_left = 37.0
+offset_top = 4.0
+offset_right = 73.0
+offset_bottom = 27.0
 text = "-"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="DexBut" type="Button" parent="AbilityGeneration/Margins/VBox/Grid"]
 layout_mode = 2
 text = "Dex:"
 
 [node name="DexVal" type="Label" parent="AbilityGeneration/Margins/VBox/Grid/DexBut"]
-offset_right = 40.0
-offset_bottom = 23.0
+layout_mode = 0
+offset_left = 35.0
+offset_top = 4.0
+offset_right = 75.0
+offset_bottom = 27.0
 text = "-"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="ConBut" type="Button" parent="AbilityGeneration/Margins/VBox/Grid"]
 layout_mode = 2
 text = "Con:"
 
 [node name="ConVal" type="Label" parent="AbilityGeneration/Margins/VBox/Grid/ConBut"]
-offset_right = 40.0
-offset_bottom = 23.0
+layout_mode = 0
+offset_left = 34.0
+offset_top = 4.0
+offset_right = 74.0
+offset_bottom = 27.0
 text = "-"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="IntBut" type="Button" parent="AbilityGeneration/Margins/VBox/Grid"]
 layout_mode = 2
 text = "Int:"
 
 [node name="IntVal" type="Label" parent="AbilityGeneration/Margins/VBox/Grid/IntBut"]
-offset_right = 40.0
-offset_bottom = 23.0
+layout_mode = 0
+offset_left = 34.0
+offset_top = 4.0
+offset_right = 74.0
+offset_bottom = 27.0
 text = "-"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="WisBut" type="Button" parent="AbilityGeneration/Margins/VBox/Grid"]
 layout_mode = 2
 text = "Wis:"
 
 [node name="WisVal" type="Label" parent="AbilityGeneration/Margins/VBox/Grid/WisBut"]
-offset_right = 40.0
-offset_bottom = 23.0
+layout_mode = 0
+offset_left = 33.0
+offset_top = 4.0
+offset_right = 73.0
+offset_bottom = 27.0
 text = "-"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="ChaBut" type="Button" parent="AbilityGeneration/Margins/VBox/Grid"]
 layout_mode = 2
 text = "Cha:"
 
 [node name="ChaVal" type="Label" parent="AbilityGeneration/Margins/VBox/Grid/ChaBut"]
-offset_right = 40.0
-offset_bottom = 23.0
+layout_mode = 0
+offset_left = 33.0
+offset_top = 4.0
+offset_right = 73.0
+offset_bottom = 27.0
 text = "-"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="Tooltip" type="PanelContainer" parent="AbilityGeneration/Margins/VBox"]
 visible = false

--- a/Scenes/CharacterCreation/CharacterCreation.tscn
+++ b/Scenes/CharacterCreation/CharacterCreation.tscn
@@ -195,7 +195,7 @@ text = "-"
 
 [node name="WisBut" type="Button" parent="AbilityGeneration/Margins/VBox/Grid"]
 layout_mode = 2
-text = "Wis: -"
+text = "Wis:"
 
 [node name="WisVal" type="Label" parent="AbilityGeneration/Margins/VBox/Grid/WisBut"]
 offset_right = 40.0
@@ -272,7 +272,7 @@ layout_mode = 0
 offset_right = 40.0
 offset_bottom = 40.0
 script = SubResource("GDScript_i3y6d")
-button_paths = Array[NodePath]([NodePath("../AbilityGeneration/Margins/VBox/Grid/StrBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/DexBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/ConBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/IntBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/WisBut/WisVal"), NodePath("../AbilityGeneration/Margins/VBox/Grid/ChaBut")])
+button_paths = Array[NodePath]([NodePath("../AbilityGeneration/Margins/VBox/Grid/StrBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/DexBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/ConBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/IntBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/WisBut"), NodePath("../AbilityGeneration/Margins/VBox/Grid/ChaBut")])
 
 [node name="RaceChoose" type="PanelContainer" parent="."]
 visible = false

--- a/Scripts/CharacterCreation/CharacterCreation.gd
+++ b/Scripts/CharacterCreation/CharacterCreation.gd
@@ -4,14 +4,14 @@ extends Control
 const ABIL_ORDER := ["Str", "Dex", "Con", "Int", "Wis", "Chr"]  # display text
 # (If you prefer "Cha" instead of "Chr", just change it here.)
 
-# Grab the six label nodes in order
-@onready var _abil_labels: Array[Label] = [
-	$AbilityGeneration/Margins/VBox/Grid/StrBut,
-	$AbilityGeneration/Margins/VBox/Grid/DexBut,
-	$AbilityGeneration/Margins/VBox/Grid/ConBut,
-	$AbilityGeneration/Margins/VBox/Grid/IntBut,
-	$AbilityGeneration/Margins/VBox/Grid/WisBut,
-	$AbilityGeneration/Margins/VBox/Grid/ChaBut,
+# Grab the six value labels (to the right of each ability)
+@onready var _abil_value_labels: Array[Label] = [
+        $AbilityGeneration/Margins/VBox/Grid/StrBut/StrVal,
+        $AbilityGeneration/Margins/VBox/Grid/DexBut/DexVal,
+        $AbilityGeneration/Margins/VBox/Grid/ConBut/ConVal,
+        $AbilityGeneration/Margins/VBox/Grid/IntBut/IntVal,
+        $AbilityGeneration/Margins/VBox/Grid/WisBut/WisVal,
+        $AbilityGeneration/Margins/VBox/Grid/ChaBut/ChaVal,
 ]
 # ======= Ability Generation =======
 enum GenMethod {
@@ -135,8 +135,8 @@ func _on_revert_pressed() -> void:
 func _reset_roll_ui() -> void:
 	current_roll.clear()
 	_lbl_total.text = "Total: –"
-	for i in _abil_labels.size():
-		_abil_labels[i].text = "%s: -" % ABIL_ORDER[i]
+        for label in _abil_value_labels:
+                label.text = "-"
 	_lbl_stored.text = "Stored: –"
 	_btn_revert.disabled = true
 	var rolling_allowed := gen_method != GenMethod.POINT_BUY
@@ -145,11 +145,11 @@ func _reset_roll_ui() -> void:
 
 
 func _update_roll_display() -> void:
-	for i in _abil_labels.size():
-		var val_text := "-"
-		if i < current_roll.size():
-			val_text = str(current_roll[i])
-		_abil_labels[i].text = "%s: %s" % [ABIL_ORDER[i], val_text]
+        for i in _abil_value_labels.size():
+                var val_text := "-"
+                if i < current_roll.size():
+                        val_text = str(current_roll[i])
+                _abil_value_labels[i].text = val_text
 	_lbl_total.text = "Total: %s" % (str(_sum(current_roll)) if current_roll.size() == 6 else "–")
 	_btn_store.disabled = current_roll.size() != 6
 

--- a/Scripts/CharacterCreation/CharacterCreation.gd
+++ b/Scripts/CharacterCreation/CharacterCreation.gd
@@ -6,12 +6,12 @@ const ABIL_ORDER := ["Str", "Dex", "Con", "Int", "Wis", "Chr"]  # display text
 
 # Grab the six value labels (to the right of each ability)
 @onready var _abil_value_labels: Array[Label] = [
-        $AbilityGeneration/Margins/VBox/Grid/StrBut/StrVal,
-        $AbilityGeneration/Margins/VBox/Grid/DexBut/DexVal,
-        $AbilityGeneration/Margins/VBox/Grid/ConBut/ConVal,
-        $AbilityGeneration/Margins/VBox/Grid/IntBut/IntVal,
-        $AbilityGeneration/Margins/VBox/Grid/WisBut/WisVal,
-        $AbilityGeneration/Margins/VBox/Grid/ChaBut/ChaVal,
+		$AbilityGeneration/Margins/VBox/Grid/StrBut/StrVal,
+		$AbilityGeneration/Margins/VBox/Grid/DexBut/DexVal,
+		$AbilityGeneration/Margins/VBox/Grid/ConBut/ConVal,
+		$AbilityGeneration/Margins/VBox/Grid/IntBut/IntVal,
+		$AbilityGeneration/Margins/VBox/Grid/WisBut/WisVal,
+		$AbilityGeneration/Margins/VBox/Grid/ChaBut/ChaVal,
 ]
 # ======= Ability Generation =======
 enum GenMethod {
@@ -135,8 +135,8 @@ func _on_revert_pressed() -> void:
 func _reset_roll_ui() -> void:
 	current_roll.clear()
 	_lbl_total.text = "Total: –"
-        for label in _abil_value_labels:
-                label.text = "-"
+	for label in _abil_value_labels:
+		label.text = "-"
 	_lbl_stored.text = "Stored: –"
 	_btn_revert.disabled = true
 	var rolling_allowed := gen_method != GenMethod.POINT_BUY
@@ -145,11 +145,11 @@ func _reset_roll_ui() -> void:
 
 
 func _update_roll_display() -> void:
-        for i in _abil_value_labels.size():
-                var val_text := "-"
-                if i < current_roll.size():
-                        val_text = str(current_roll[i])
-                _abil_value_labels[i].text = val_text
+	for i in _abil_value_labels.size():
+		var val_text := "-"
+		if i < current_roll.size():
+			val_text = str(current_roll[i])
+		_abil_value_labels[i].text = val_text
 	_lbl_total.text = "Total: %s" % (str(_sum(current_roll)) if current_roll.size() == 6 else "–")
 	_btn_store.disabled = current_roll.size() != 6
 
@@ -167,9 +167,8 @@ func _on_generation_next_pressed() -> void:
 		rolled_values = current_roll.duplicate() if current_roll.size() == 6 else _roll_by_method(gen_method)
 
 	_show_only("AbilityAssigning")
-	# If your AbilityAssigning node has an initializer, call it here:
-	# if _panels["AbilityAssigning"].has_method("init_assigning"):
-	#     _panels["AbilityAssigning"].call("init_assigning", gen_method, point_buy_pool, rolled_values)
+	assert(rolled_values.size() == 6, "AbilityAssigning requires exactly 6 values")
+	$AbilityAssigning.init_assigning(gen_method, point_buy_pool, rolled_values)
 
 func _on_generation_back_pressed() -> void:
 	pass # keep for future splash/menu


### PR DESCRIPTION
## Summary
- show ability roll values in labels next to each ability button
- fix wisdom button text and assignment mapping

## Testing
- `dotnet build`
- Attempted to run `godot --headless --quit` *(missing: command not found)*
- `apt-get install -y godot4` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11d8f68ac8326a10fed31f7069994