### PR TITLE
Delay ability swap until initialization

### DIFF
--- a/.godot/editor/Main.tscn-editstate-a8e1520d83f25710dd4e3da8c6f32601.cfg
+++ b/.godot/editor/Main.tscn-editstate-a8e1520d83f25710dd4e3da8c6f32601.cfg
@@ -8,7 +8,7 @@ Anim={
 "grid_snap_active": false,
 "grid_step": Vector2(8, 8),
 "grid_visibility": 1,
-"ofs": Vector2(-1294.79, -200.122),
+"ofs": Vector2(-521.364, -38.6364),
 "primary_grid_step": Vector2i(8, 8),
 "show_group_gizmos": true,
 "show_guides": true,
@@ -34,7 +34,7 @@ Anim={
 "snap_rotation_step": 0.261799,
 "snap_scale": false,
 "snap_scale_step": 0.1,
-"zoom": 0.513158
+"zoom": 1.1
 }
 3D={
 "fov": 70.01,

--- a/.godot/editor/editor_layout.cfg
+++ b/.godot/editor/editor_layout.cfg
@@ -33,7 +33,7 @@ current_scene="res://Scenes/CharacterCreation/CharacterCreation.tscn"
 center_split_offset=-352
 selected_default_debugger_tab_idx=0
 selected_main_editor_idx=2
-selected_bottom_panel_item=1
+selected_bottom_panel_item=0
 
 [EditorWindow]
 
@@ -44,7 +44,7 @@ position=Vector2i(0, 23)
 [ScriptEditor]
 
 open_scripts=["res://Scripts/CharacterCreation/AbilityAssigning.gd", "res://Scripts/CharacterCreation/CharacterCreation.gd", "res://Scripts/DataSchemas/CharacterData.cs", "res://Scripts/DataSchemas/ClassData.cs", "res://Scripts/DataSchemas/FeatData.cs", "res://Scripts/Main.gd", "res://Scripts/DataSchemas/RaceData.cs", "res://Scripts/DataSchemas/SpellData.cs"]
-selected_script=""
+selected_script="res://Scripts/CharacterCreation/AbilityAssigning.gd"
 open_help=[]
 script_split_offset=200
 list_split_offset=0

--- a/.godot/editor/script_editor_cache.cfg
+++ b/.godot/editor/script_editor_cache.cfg
@@ -101,10 +101,10 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 36,
+"column": 14,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 23,
+"row": 19,
 "scroll_position": 14.0,
 "selection": false,
 "syntax_highlighter": "GDScript"

--- a/Scenes/CharacterCreation/CharacterCreation.tscn
+++ b/Scenes/CharacterCreation/CharacterCreation.tscn
@@ -45,13 +45,6 @@ func _ready() -> void:
 		push_error(\"AbilityAssigning: expected 6 buttons, got %d. Check 'button_paths' in the inspector.\" % _buttons.size())
 		return
 
-	# Connect pressed handlers
-	for i in _buttons.size():
-		var idx := i
-		# Avoid duplicate connects in case of scene reloads
-		if not _buttons[i].pressed.is_connected(_on_button_pressed.bind(idx)):
-			_buttons[i].pressed.connect(_on_button_pressed.bind(idx))
-
 	_clear_selection()
 
 func init_assigning(_gen_method: int, _point_buy_pool: int, values: Array[int]) -> void:
@@ -60,12 +53,20 @@ func init_assigning(_gen_method: int, _point_buy_pool: int, values: Array[int]) 
 		push_error(\"init_assigning: expected 6 values, got %d\" % values.size())
 		return
 	ability_values = values.duplicate()
+	# Connect pressed handlers once ability_values is ready
+	for i in _buttons.size():
+		var idx := i
+		# Avoid duplicate connects in case of scene reloads
+		if not _buttons[i].pressed.is_connected(_on_button_pressed.bind(idx)):
+			_buttons[i].pressed.connect(_on_button_pressed.bind(idx))
 	for i in _buttons.size():
 		_set_button_text(i, ability_values[i])
 		_set_highlight(i, false)
 	_selected = -1
 
 func _on_button_pressed(index: int) -> void:
+	if ability_values.size() != 6:
+		return
 	# First pick
 	if _selected == -1:
 		_selected = index


### PR DESCRIPTION
## Summary
- avoid early ability button presses by connecting signals after values are initialized
- guard against out-of-range ability swaps when values are missing

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68c1289d7528832692d03d08202b239b